### PR TITLE
Catch sync failures and log when they occur

### DIFF
--- a/src/matrix/Sync.tsx
+++ b/src/matrix/Sync.tsx
@@ -168,6 +168,11 @@ const syncForever = async(setPosts: any, setMessages: any, setSynced: any, setFo
       updatePosts()
       updateMessages()
     }
+    if(!res.data || !res.data.next_batch){
+      console.log(`Sync Request Returned No Batch: ${JSON.stringify(res)}`)
+      await new Promise(resolve => setTimeout(resolve, 1000))
+      continue
+    }
     await Storage.set({key: sync_key, value: JSON.stringify({filter_id: filter_id, since: res.data.next_batch})})
   }
 }


### PR DESCRIPTION
Resolves: #5 

problem
======
When a sync request fails, we do not handle that failure well, and the react app crashes.

solution
======
Catch the error, log it, and sleep for 1 sec before attempting the next sync. We sleep so that an error that is going to persistently occur does not trigger an aggressive loop. 

Hopefully issues are limited to connectivity / request abortion as opposed to an issue with application logic. With these changes, we'll at least be able to see any more serious errors logged in the console.

note
===
I was able to reproduce the bug by refreshing the page (causing the sync request to abort).
![no_batch_error](https://user-images.githubusercontent.com/1624468/97334019-729c9900-1839-11eb-8b04-e8f369d684d1.png)
